### PR TITLE
Close issue #28: Log Unknown Video Length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning].
 [Unreleased]
 ------------
 
+### Added
+
+- When the browser cannot determine video length in Front-end, this fact is
+  logged into the console
+
 
 [0.1.0] – 2018-02-27
 --------------------

--- a/front-end/src/components/Playlist.jsx
+++ b/front-end/src/components/Playlist.jsx
@@ -80,6 +80,11 @@ class Playlist extends Component {
         );
       }
       else {
+        console.log(
+          'Videos\'s length could not be determined.' + '\n'
+          + 'It will play to its end, but it will not fade out.' + '\n\n'
+          + 'Video: ', this.currentVideoElement
+        );
         this.currentVideoElement.addEventListener('ended', this.transition);
       }
     }


### PR DESCRIPTION
Closes issue #28: Log Unknown Video Length

> As a user, when the browser cannot determine video length in Front-end, I want this fact logged into console, so that I know if the video will not fade out like it regularly does.