### PR TITLE
Close issue #27: Full Screen Instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning].
 
 - When the browser cannot determine video length in Front-end, this fact is
   logged into the console
+- Instructions on how to set Front-end to full screen mode with "F11" key
 
 
 [0.1.0] – 2018-02-27

--- a/front-end/src/components/Playlists.jsx
+++ b/front-end/src/components/Playlists.jsx
@@ -29,6 +29,9 @@ class Playlists extends Component {
           This web app plays the playlists that have been created in Management
           UI.
         </p>
+        <p>
+          You can toggle full screen mode by pressing the <kbd>F11</kbd> key.
+        </p>
         <section>
           <h2>
             Playlists


### PR DESCRIPTION
Closes issue #27: Full Screen Instructions

> Include instructions on how to set the browsers to full screen mode in Front-end.
>
> Full screen is usually triggered with the "F11" key.