### PR TITLE
Close issue #21: Recommend NVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Versioning].
 - When the browser cannot determine video length in Front-end, this fact is
   logged into the console
 - Instructions on how to set Front-end to full screen mode with "F11" key
+- Recommendation to use Node Version Manager (NVM)
 
 
 [0.1.0] – 2018-02-27

--- a/README.md
+++ b/README.md
@@ -26,12 +26,8 @@ Getting Started / Installation
    This project has only been tested to work on the following environment:
    - Operating system: Ubuntu 16.04.3 LTS Desktop AMD64
    - Run-time environment: Node.js 8.9.4
-     - I found the ["Installing Node.js via package manager"][Node.js
-       installation] instructions to be the easiest way to install it.
-       - To use this method however, you first need to install `curl` with:
-         ```
-         sudo apt-get install curl
-         ```
+     - (Recommended) Install Node.js using [Node Version Manager (NVM)] (or its
+       [Windows-equivalents]).
    - Web browser: Mozilla Firefox (latest)
 2. Start [Back-end](./back-end/).
 3. Start [Management UI](./management-ui/), and create some signs, playlists and
@@ -53,5 +49,7 @@ Copyright © 2018 Henrik Franciscus Leppä
 All rights reserved.
 
 
+[Node Version Manager (NVM)]: https://github.com/creationix/nvm
+[Windows-equivalents]: https://github.com/creationix/nvm#important-notes
 [git-flow]: https://github.com/nvie/gitflow
 [Node.js installation]: https://nodejs.org/en/download/package-manager/#debian-and-ubuntu-based-linux-distributions


### PR DESCRIPTION
Closes issue #21: Recommend NVM

> Installing Node through the package manager (as currently suggested) (1) causes it to be installed for all users, (2) requires root privileges, and (3) can cause problems if the user has many projects with different Node versions.
>
> Because of all these problems it is better to recommend [NVM (Node Version Manager)](https://github.com/creationix/nvm) (and its [Windows-equivalents](https://github.com/creationix/nvm#important-notes)) instead.