### PR TITLE
Close issue #20: Windows Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning].
   logged into the console
 - Instructions on how to set Front-end to full screen mode with "F11" key
 - Recommendation to use Node Version Manager (NVM)
+- Support for Microsoft Windows
 
 
 [0.1.0] – 2018-02-27

--- a/README.md
+++ b/README.md
@@ -21,14 +21,22 @@ This project is made up of 3 subprojects:
 Getting Started / Installation
 ------------------------------
 
-1. Setup the environment.
+This project is cross-platform software, and as such it should be possible to
+run it on any operating system that supports the software listed in the
+"Install" step, including, but not limited to: GNU/Linux, BSD, Microsoft
+Windows, and macOS.
 
-   This project has only been tested to work on the following environment:
-   - Operating system: Ubuntu 16.04.3 LTS Desktop AMD64
-   - Run-time environment: Node.js 8.9.4
-     - (Recommended) Install Node.js using [Node Version Manager (NVM)] (or its
-       [Windows-equivalents]).
-   - Web browser: Mozilla Firefox (latest)
+### Steps
+
+1. Install:
+   - Run-time environment:
+     - Node.js 8.9.4
+       - (Recommended) Install using [Node Version Manager (NVM)] (or its
+         [Windows-equivalents]).
+   - Web browser:
+     - Mozilla Firefox (latest) \
+       or
+     - Chromium / Google Chrome (latest)
 2. Start [Back-end](./back-end/).
 3. Start [Management UI](./management-ui/), and create some signs, playlists and
    (optionally) upload some files.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,10 @@ HFL Signage Player
 
 Digital signage player written by Henrik Franciscus Leppä
 
-Main technologies:
+
+Main Technologies
+-----------------
+
 - [Express.js 4](https://expressjs.com/)
 - [Material-UI v1](https://material-ui-next.com/)
 - [Node.js](https://nodejs.org/)
@@ -11,6 +14,10 @@ Main technologies:
 - [React.js](https://reactjs.org/)
 - [React Router 4](https://github.com/ReactTraining/react-router)
 - [Redux](https://redux.js.org/)
+
+
+Subprojects
+-----------
 
 This project is made up of 3 subprojects:
 - [Back-end](./back-end/)

--- a/back-end/package-lock.json
+++ b/back-end/package-lock.json
@@ -742,6 +742,12 @@
         "through": "2.3.8"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -935,6 +941,12 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "gar": {
       "version": "1.0.3",
@@ -1165,6 +1177,12 @@
         "falafel": "1.2.0",
         "through2": "0.6.5"
       }
+    },
+    "interpret": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.1.0.tgz",
+      "integrity": "sha1-ftGxQQxqDg94z5XTuEQMY/eLhhQ=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.6.0",
@@ -1853,6 +1871,12 @@
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
+    "path-parse": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+      "dev": true
+    },
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
@@ -2495,6 +2519,15 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.6.0"
+      }
+    },
     "repeating": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
@@ -2556,6 +2589,15 @@
       "integrity": "sha512-0YHa2afepsLfQvwQ1P2XvDZnGOUia5sC07ZijIRU2dnsRxnuilXWF6B2CFaKGDA9eZl39lJHrXCDsnfgroRd6Q==",
       "requires": {
         "is-nil-x": "1.4.1"
+      }
+    },
+    "resolve": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.6.0.tgz",
+      "integrity": "sha512-mw7JQNu5ExIkcw4LPih0owX/TZXjD/ZUF/ZQ/pDnkw3ZKhDcZZw5klmBlj6gVMwjQ3Pz5Jgu7F3d0jcDVuEWdw==",
+      "dev": true,
+      "requires": {
+        "path-parse": "1.0.5"
       }
     },
     "safe-buffer": {
@@ -2635,6 +2677,52 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "shx": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/back-end/package.json
+++ b/back-end/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "start": "npm run ensure-env && node app.js",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "ensure-env": "cp --no-clobber .env.default .env"
+    "ensure-env": "shx cp -n .env.default .env"
   },
   "dependencies": {
     "cors": "^2.8.4",
@@ -27,5 +27,8 @@
     "multer": "^1.3.0",
     "pouchdb": "^6.4.3",
     "serve-index": "^1.9.1"
+  },
+  "devDependencies": {
+    "shx": "^0.2.2"
   }
 }

--- a/front-end/package-lock.json
+++ b/front-end/package-lock.json
@@ -2754,6 +2754,12 @@
         "event-emitter": "0.3.5"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
@@ -8853,6 +8859,15 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
+    },
     "recursive-readdir": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.1.tgz",
@@ -9426,10 +9441,40 @@
         "jsonify": "0.0.0"
       }
     },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+    },
+    "shx": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/front-end/package.json
+++ b/front-end/package.json
@@ -18,7 +18,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "ensure-env": "cp --no-clobber .env.default .env"
+    "ensure-env": "shx cp -n .env.default .env"
   },
   "dependencies": {
     "pouchdb": "^6.4.3",
@@ -29,5 +29,8 @@
     "react-scripts": "1.1.1",
     "redux": "^3.7.2",
     "redux-pouchdb": "^0.1.1"
+  },
+  "devDependencies": {
+    "shx": "^0.2.2"
   }
 }

--- a/management-ui/package-lock.json
+++ b/management-ui/package-lock.json
@@ -2815,6 +2815,12 @@
         "event-emitter": "0.3.5"
       }
     },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
     "es6-promise": {
       "version": "4.2.4",
       "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
@@ -9179,6 +9185,15 @@
         "set-immediate-shim": "1.0.1"
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "1.5.0"
+      }
+    },
     "recompose": {
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.26.0.tgz",
@@ -9771,10 +9786,40 @@
         "jsonify": "0.0.0"
       }
     },
+    "shelljs": {
+      "version": "0.7.8",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "dev": true,
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.1.0",
+        "rechoir": "0.6.2"
+      }
+    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww=="
+    },
+    "shx": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.2.2.tgz",
+      "integrity": "sha1-CjBNAgsO3xMGrYFXDoDwNG31ijk=",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "1.1.0",
+        "minimist": "1.2.0",
+        "shelljs": "0.7.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        }
+      }
     },
     "signal-exit": {
       "version": "3.0.2",

--- a/management-ui/package.json
+++ b/management-ui/package.json
@@ -18,7 +18,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "ensure-env": "cp --no-clobber .env.default .env"
+    "ensure-env": "shx cp -n .env.default .env"
   },
   "dependencies": {
     "material-ui": "^1.0.0-beta.34",
@@ -32,5 +32,8 @@
     "redux": "^3.7.2",
     "redux-pouchdb": "^0.1.1",
     "uuid": "^3.2.1"
+  },
+  "devDependencies": {
+    "shx": "^0.2.2"
   }
 }


### PR DESCRIPTION
Close issues #20: Windows Support

> The current version depends on Unix command `cp` which is not available for Microsoft Windows. There are NPM packages like [Shx](https://github.com/shelljs/shx) that allow using Unix commands on all environments.