### PR TITLE
Close issue #39: Main Feature List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ Versioning].
 
 [(See this file in `develop` branch.)][Development Changelog]
 
+### Added
+
+- Main feature list
+
+### Changed
+
+- Screenshot captions to describe what is happening, as opposed to where they
+  are from
+
 
 [0.2.0] – 2018-03-29
 --------------------

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Digital signage player written by Henrik Franciscus Leppä
 
 <table>
   <tr>
-    <th scope="col">Management UI: Signs</th>
-    <th scope="col">Management UI: Playlists</th>
-    <th scope="col">Front-end: Playlist</th>
+    <th scope="col">Creating signs</th>
+    <th scope="col">Adding signs to a playlist</th>
+    <th scope="col">Playing a playlist</th>
   </tr>
   <tr>
     <td>
@@ -39,6 +39,20 @@ Digital signage player written by Henrik Franciscus Leppä
     </td>
   </tr>
 </table>
+
+
+Main Features
+-------------
+
+- Creating digital signage using HTML.
+- Uploading images and videos to include in the HTML.
+- Each static sign stays visible for 7 seconds.
+- Each sign with a video stays visible for the duration of the video.
+- When a playlist moves to the next sign:
+  - ...signs fade in and fade out visually, and
+  - ...sounds of videos cross-fade.
+- All work is autosaved, and no work is lost, even when offline.
+- Cross-platform.
 
 
 Main Technologies

--- a/back-end/README.md
+++ b/back-end/README.md
@@ -5,9 +5,9 @@ HFL Signage Player: Back-end
 
 <table>
   <tr>
-    <th scope="col">Terminal</th>
-    <th scope="col">Home</th>
-    <th scope="col">Uploads</th>
+    <th scope="col">Command-line</th>
+    <th scope="col">Front page</th>
+    <th scope="col">Browsing uploads</th>
   </tr>
   <tr>
     <td>

--- a/front-end/README.md
+++ b/front-end/README.md
@@ -5,8 +5,8 @@ Front-end for [HFL Signage Player]
 
 <table>
   <tr>
-    <th scope="col">Home</th>
-    <th scope="col">Playlist</th>
+    <th scope="col">Choosing a playlist</th>
+    <th scope="col">Playing a playlist</th>
   </tr>
   <tr>
     <td>

--- a/management-ui/README.md
+++ b/management-ui/README.md
@@ -5,9 +5,9 @@ Management UI for [HFL Signage Player]
 
 <table>
   <tr>
-    <th scope="col">Home</th>
-    <th scope="col">Signs</th>
-    <th scope="col">Playlists</th>
+    <th scope="col">Front page</th>
+    <th scope="col">Creating signs</th>
+    <th scope="col">Adding signs to a playlist</th>
   </tr>
   <tr>
     <td>


### PR DESCRIPTION
Closes issue #39: Main Feature List

> The main README should contain a brief list of main features.
>
> Additionally, the current screenshot captions tell from where they are in the application, but not what is happening. The latter is more useful than the former.